### PR TITLE
(feat) support 64 users streaming at once.

### DIFF
--- a/config/sc_serv.conf
+++ b/config/sc_serv.conf
@@ -1,5 +1,6 @@
 #
 # http://wiki.shoutcast.com/wiki/SHOUTcast_DNAS_Server_2
+# Use the config builder - https://88x.pl/config_builder/config_builder.html
 #
 
 password=haxm3br0dj
@@ -9,13 +10,11 @@ log=1
 screenlog=1
 banfile=control/sc_serv.ban
 ripfile=control/sc_serv.rip
-publicserver=always
+publicserver=never
+maxuser=64
 
 streamid_1=1
 streampath_1=/mpr1
-streammaxuser_1=20
-streampassword_1=whipthatllama
-streamadminpassword_1=letmeinbr0
 streambackupurl_1=http://anonradio.net:8000/anonradio
 
 streamid_2=2


### PR DESCRIPTION
Changes:
   - Remove nag notice by setting to private
   - Moved user limits out of /mpr
   - Bumped max users up to 64 from default and stream limit
   - Add link to config generator
   - Removed stream passwords for favor of global passwords